### PR TITLE
Remove RssFeed field from RssItem and fix issue #5

### DIFF
--- a/src/nl/matshofman/saxrssreader/RssHandler.java
+++ b/src/nl/matshofman/saxrssreader/RssHandler.java
@@ -47,7 +47,6 @@ public class RssHandler extends DefaultHandler {
 		
 		if(qName.equals("item") && rssFeed != null) {
 			rssItem = new RssItem();
-			rssItem.setFeed(rssFeed);
 			rssFeed.addRssItem(rssItem);
 		}
 	}
@@ -76,7 +75,7 @@ public class RssHandler extends DefaultHandler {
 			} catch (InvocationTargetException e) {
 			}
 			
-		} else if (rssItem != null) {
+		} else {
 			// Parse item properties
 			
 			try {

--- a/src/nl/matshofman/saxrssreader/RssItem.java
+++ b/src/nl/matshofman/saxrssreader/RssItem.java
@@ -27,7 +27,6 @@ import android.os.Parcelable;
 
 public class RssItem implements Comparable<RssItem>, Parcelable {
 
-	private RssFeed feed;
 	private String title;
 	private String link;
 	private Date pubDate;
@@ -46,7 +45,6 @@ public class RssItem implements Comparable<RssItem>, Parcelable {
 		pubDate = (Date) data.getSerializable("pubDate");
 		description = data.getString("description");
 		content = data.getString("content");
-		feed = data.getParcelable("feed");
 		
 	}
 
@@ -59,7 +57,6 @@ public class RssItem implements Comparable<RssItem>, Parcelable {
 		data.putSerializable("pubDate", pubDate);
 		data.putString("description", description);
 		data.putString("content", content);
-		data.putParcelable("feed", feed);
 		dest.writeBundle(data);
 	}
 	
@@ -77,14 +74,6 @@ public class RssItem implements Comparable<RssItem>, Parcelable {
 		return 0;
 	}
 	
-	public RssFeed getFeed() {
-		return feed;
-	}
-
-	public void setFeed(RssFeed feed) {
-		this.feed = feed;
-	}
-
 	public String getTitle() {
 		return title;
 	}


### PR DESCRIPTION
An RssItem shouldn't hold a reference to it's RssFeed. I removed the feed field from RssItem, which causes the circular bundel problem (issue #5 ) to go away.
